### PR TITLE
Update vite.config.js to remove basepath

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,5 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/jsroy.dev',
   plugins: [svelte()],
 })


### PR DESCRIPTION
- Base path was set for previous gh-pages deployment 
- now custom url does not require basepath